### PR TITLE
Add modular reusable CI workflows

### DIFF
--- a/.github/workflows/command-check.yml
+++ b/.github/workflows/command-check.yml
@@ -1,0 +1,35 @@
+name: Repository Command Check
+
+on:
+  workflow_call:
+    inputs:
+      command:
+        description: Repository-owned check command
+        required: true
+        type: string
+      working_directory:
+        description: Directory in which to execute the command
+        type: string
+        default: '.'
+      runs_on:
+        description: Runner label override
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ${{ inputs.runs_on || vars.CK_RUNS_ON || 'ubuntu-latest' }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+      - name: Run repository check
+        env:
+          CK_COMMAND: ${{ inputs.command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"

--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -124,6 +124,14 @@ on:
           demo login, then `npm run test:e2e`. Slow — scheduled caller only.
         type: boolean
         default: false
+      extra_phpunit_config:
+        description: >-
+          Run one additional PHPUnit suite with this repository-relative XML
+          configuration after the normal headless coverage suite. Useful for
+          database-free or differently bootstrapped tests that still need the
+          materialized vendor directory or sibling extension. Empty skips it.
+        type: string
+        default: ''
       runs_on:
         description: >-
           Runner label for all jobs. Resolution: this input, else the caller's
@@ -335,6 +343,7 @@ jobs:
       - name: Validate inputs
         env:
           CK_SIBLING_REPO: ${{ inputs.sibling_repo }}
+          CK_EXTRA_PHPUNIT_CONFIG: ${{ inputs.extra_phpunit_config }}
         run: |
           [[ "$CK_EXT_KEY" =~ ^[A-Za-z][A-Za-z0-9_]*$ ]] \
             || { echo "invalid extension key: $CK_EXT_KEY" >&2; exit 1; }
@@ -342,6 +351,12 @@ jobs:
           # be owner/repo, because it becomes a checkout target and a path.
           [[ -z "$CK_SIBLING_REPO" || "$CK_SIBLING_REPO" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$ ]] \
             || { echo "invalid sibling_repo (expected owner/repo): $CK_SIBLING_REPO" >&2; exit 1; }
+          [[ -z "$CK_EXTRA_PHPUNIT_CONFIG" || \
+             ( "$CK_EXTRA_PHPUNIT_CONFIG" =~ ^[A-Za-z0-9_./-]+$ &&
+               "$CK_EXTRA_PHPUNIT_CONFIG" != /* &&
+               "$CK_EXTRA_PHPUNIT_CONFIG" != *../* &&
+               "$CK_EXTRA_PHPUNIT_CONFIG" != ../* ) ]] \
+            || { echo "invalid extra_phpunit_config: $CK_EXTRA_PHPUNIT_CONFIG" >&2; exit 1; }
 
       # --- Frontend steps (opt-in via npm_ci / js_tests / bun) --------------
       #
@@ -609,6 +624,16 @@ jobs:
         run: |
           docker compose -f "$CK_COMPOSE_FILE" exec -T -u www-data app bash -c \
             "cd /var/www/html/ext/$CK_EXT_KEY && ckcoverage tests/phpunit"
+
+      - name: Additional PHPUnit suite
+        if: ${{ !cancelled() && steps.stack.outcome == 'success' && inputs.extra_phpunit_config != '' }}
+        env:
+          CK_EXTRA_PHPUNIT_CONFIG: ${{ inputs.extra_phpunit_config }}
+        run: |
+          docker compose -f "$CK_COMPOSE_FILE" exec -T -u www-data \
+            -e "CK_EXT_KEY=$CK_EXT_KEY" \
+            -e "CK_EXTRA_PHPUNIT_CONFIG=$CK_EXTRA_PHPUNIT_CONFIG" app bash -c \
+            'cd "/var/www/html/ext/$CK_EXT_KEY" && phpunit -c "$CK_EXTRA_PHPUNIT_CONFIG"'
 
       - name: PHPStan
         if: ${{ !cancelled() && steps.stack.outcome == 'success' }}

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -53,14 +53,19 @@ on:
         description: 'Publish the GitHub release as a draft'
         type: boolean
         default: false
+      runs_on:
+        description: Runner label override for all release jobs
+        type: string
+        default: ''
 
 permissions:
   contents: read
 
 jobs:
   dist:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs_on || vars.CK_RUNS_ON || 'ubuntu-latest' }}
     env:
+      COMPOSE_PROJECT_NAME: ck-${{ github.run_id }}-${{ github.run_attempt }}-release
       # Inputs reach the shell through the environment, never through expression
       # interpolation inside `run:` — an interpolated input IS the script text.
       # Read by the smoke stack's ${CIVIKITCHEN_IMAGE} on every compose call,
@@ -202,7 +207,7 @@ jobs:
 
   publish:
     needs: dist
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs_on || vars.CK_RUNS_ON || 'ubuntu-latest' }}
     # The only job that writes anything, and the only one with a token that can.
     permissions:
       contents: write

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,100 @@
+name: Frontend CI
+
+on:
+  workflow_call:
+    inputs:
+      working_directory:
+        description: Directory containing package.json and the lockfile
+        type: string
+        default: '.'
+      node_version:
+        description: Node.js major used by the project
+        type: string
+        default: '24'
+      cache_dependency_path:
+        description: Path to package-lock.json, relative to the repository root
+        type: string
+        default: 'package-lock.json'
+      install_command:
+        description: Dependency installation command
+        type: string
+        default: 'npm ci'
+      typecheck_command:
+        description: Optional type-check command
+        type: string
+        default: ''
+      lint_command:
+        description: Optional lint command
+        type: string
+        default: ''
+      test_command:
+        description: Optional unit-test command
+        type: string
+        default: 'npm test'
+      build_command:
+        description: Optional production-build command
+        type: string
+        default: ''
+      verify_command:
+        description: Optional command that verifies generated output
+        type: string
+        default: ''
+      runs_on:
+        description: Runner label override
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    runs-on: ${{ inputs.runs_on || vars.CK_RUNS_ON || 'ubuntu-latest' }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.cache_dependency_path }}
+
+      - name: Install dependencies
+        env:
+          CK_COMMAND: ${{ inputs.install_command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"
+
+      - name: Type check
+        if: ${{ inputs.typecheck_command != '' }}
+        env:
+          CK_COMMAND: ${{ inputs.typecheck_command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"
+
+      - name: Lint
+        if: ${{ inputs.lint_command != '' }}
+        env:
+          CK_COMMAND: ${{ inputs.lint_command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"
+
+      - name: Unit tests
+        if: ${{ inputs.test_command != '' }}
+        env:
+          CK_COMMAND: ${{ inputs.test_command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"
+
+      - name: Build
+        if: ${{ inputs.build_command != '' }}
+        env:
+          CK_COMMAND: ${{ inputs.build_command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"
+
+      - name: Verify build output
+        if: ${{ inputs.verify_command != '' }}
+        env:
+          CK_COMMAND: ${{ inputs.verify_command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -1,0 +1,131 @@
+name: Standalone Playwright E2E
+
+on:
+  workflow_call:
+    inputs:
+      working_directory:
+        description: Directory containing the Playwright project
+        type: string
+        default: 'tests/e2e'
+      node_version:
+        description: Node.js major used by the test project
+        type: string
+        default: '24'
+      cache_dependency_path:
+        description: Path to the E2E package-lock.json
+        type: string
+        default: 'tests/e2e/package-lock.json'
+      install_command:
+        description: Optional dependency installation command
+        type: string
+        default: ''
+      browser_install_command:
+        description: Optional Playwright browser installation command
+        type: string
+        default: ''
+      prepare_command:
+        description: Optional build or stack-setup command
+        type: string
+        default: ''
+      test_command:
+        description: Playwright test command
+        type: string
+        default: 'npx playwright test'
+      failure_command:
+        description: Optional diagnostic command run after a failure
+        type: string
+        default: ''
+      cleanup_command:
+        description: Optional cleanup command, always run last
+        type: string
+        default: ''
+      base_url:
+        description: Optional BASE_URL exposed to the tests
+        type: string
+        default: ''
+      artifact_paths:
+        description: Newline-separated artifact paths, relative to repository root
+        type: string
+        default: |-
+          tests/e2e/playwright-report/
+          tests/e2e/test-results/
+      artifact_retention_days:
+        description: Number of days to retain Playwright artifacts
+        type: number
+        default: 7
+      timeout_minutes:
+        description: Maximum runtime for the E2E job
+        type: number
+        default: 30
+      runs_on:
+        description: Runner label override
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ${{ inputs.runs_on || vars.CK_RUNS_ON || 'ubuntu-latest' }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+    env:
+      BASE_URL: ${{ inputs.base_url }}
+      COMPOSE_PROJECT_NAME: ck-${{ github.run_id }}-${{ github.run_attempt }}-playwright
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.cache_dependency_path }}
+
+      - name: Install dependencies
+        if: ${{ inputs.install_command != '' }}
+        env:
+          CK_COMMAND: ${{ inputs.install_command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"
+
+      - name: Install Playwright browsers
+        if: ${{ inputs.browser_install_command != '' }}
+        env:
+          CK_COMMAND: ${{ inputs.browser_install_command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"
+
+      - name: Prepare test environment
+        if: ${{ inputs.prepare_command != '' }}
+        env:
+          CK_COMMAND: ${{ inputs.prepare_command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"
+
+      - name: Run Playwright tests
+        env:
+          CK_COMMAND: ${{ inputs.test_command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"
+
+      - name: Diagnostics on failure
+        if: ${{ failure() && inputs.failure_command != '' }}
+        env:
+          CK_COMMAND: ${{ inputs.failure_command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"
+
+      - name: Upload Playwright artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-report
+          path: ${{ inputs.artifact_paths }}
+          if-no-files-found: warn
+          retention-days: ${{ inputs.artifact_retention_days }}
+
+      - name: Clean up test environment
+        if: ${{ always() && inputs.cleanup_command != '' }}
+        env:
+          CK_COMMAND: ${{ inputs.cleanup_command }}
+        run: bash -euo pipefail -c "$CK_COMMAND"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Details in [Custom or older CiviCRM versions](docs/images.md#custom-or-older-civ
 - [Building locally](docs/building.md) — build args, `KEEP_GIT=1`, running the test suite locally
 - [Releases](docs/releases.md) — the versioned contract extension repos pin (`@v1` / `:v1`), how a release is cut
 - [Releasing an extension](docs/extension-releases.md) — the other direction: how a consuming extension repo cuts *its* release (`ckrelease`, the shared `extension-release.yml`)
+- [Reusable CI building blocks](docs/reusable-workflows.md) — frontend, standalone Playwright, and lightweight repository checks beside `extension-ci.yml`
 
 ## Reliability
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -1,0 +1,88 @@
+# Reusable CI building blocks
+
+`extension-ci.yml` remains the complete default for a CiviCRM extension. Three
+smaller reusable workflows cover checks that several extensions need beside
+that stack without copying checkout, toolchain, artifact, cleanup, and runner
+selection boilerplate.
+
+An extension with an additional PHPUnit configuration should keep using the
+main workflow rather than create a toolbox job:
+
+```yaml
+jobs:
+  ci:
+    uses: jfilter/civikitchen/.github/workflows/extension-ci.yml@v1
+    with:
+      key: example
+      extra_phpunit_config: phpunit-unit.xml.dist
+```
+
+That suite runs after the standard headless coverage suite and reuses the same
+materialized Composer dependencies, optional sibling checkout, and container.
+
+All jobs resolve their runner in the same order:
+
+1. the workflow's `runs_on` input;
+2. the caller repository's `CK_RUNS_ON` variable;
+3. `ubuntu-latest`.
+
+## Frontend CI
+
+`frontend-ci.yml` installs an npm project and runs the non-empty typecheck,
+lint, test, build, and output-verification commands in that order. Commands are
+passed through environment variables rather than interpolated into shell source.
+
+```yaml
+jobs:
+  frontend:
+    uses: jfilter/civikitchen/.github/workflows/frontend-ci.yml@v1
+    with:
+      working_directory: frontend
+      cache_dependency_path: frontend/package-lock.json
+      typecheck_command: npx tsc --noEmit
+      lint_command: npm run lint
+      test_command: npm test
+      build_command: npm run build
+```
+
+## Standalone Playwright E2E
+
+`playwright-e2e.yml` is for repositories whose browser suite owns its stack.
+It provides ordered install, browser-install, prepare, test, diagnostics,
+artifact, and always-run cleanup phases. Commands run inside
+`working_directory`; use an explicit `cd` when a diagnostic needs repository
+root paths.
+
+```yaml
+jobs:
+  e2e:
+    uses: jfilter/civikitchen/.github/workflows/playwright-e2e.yml@v1
+    with:
+      install_command: npm ci
+      browser_install_command: npx playwright install --with-deps chromium
+      prepare_command: bash setup.sh
+      test_command: npx playwright test
+      cleanup_command: bash teardown.sh
+```
+
+The `playwright` input on `extension-ci.yml` is still preferable when the suite
+uses the standard CiviKitchen compose stack. This standalone workflow exists
+for suites with their own setup and teardown contract.
+
+## Repository command checks
+
+`command-check.yml` checks out the caller and runs one cheap repository-owned
+command. It is intended for guards such as public-safety or generated-file
+checks that need no CiviCRM stack.
+
+```yaml
+jobs:
+  guard:
+    uses: jfilter/civikitchen/.github/workflows/command-check.yml@v1
+    with:
+      command: bash tools/qa/check-public-safe.sh
+```
+
+Deployment credentials and product-specific orchestration do not belong in
+these workflows. Keep deploys, image fleets, tenant discovery, and bespoke
+service topologies in the repository that owns them.


### PR DESCRIPTION
## Summary

- add reusable frontend, Playwright E2E, and command-check workflows
- make runner selection consistent through input, repository variable, and GitHub-hosted fallback
- allow one optional additional PHPUnit configuration in the existing extension CI environment
- document reusable workflow boundaries and caller examples

## Why

Dialogmail previously duplicated checkout, private Composer setup, sibling checkout, and container setup only to run its database-free PHPUnit suite. The generic workflow now prepares dependencies once and can run an optional second PHPUnit configuration afterward. CiviKitchen contains no Dialogmail- or Shuttle-specific behavior.

## Validation

- `gmake test`
- `gmake lint`
- actionlint
- ShellCheck
- zizmor
- PHP syntax and profile schema validation
